### PR TITLE
Fix content type for cached responses and remove double decodeURIComponent

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -52,7 +52,9 @@ app.get('/health', (req, res) => {
 // Proxy endpoint with caching
 app.get('/api/v1/streamingProxy', async (req, res) => {
   try {
-    const url = decodeURIComponent(req.query.url);
+    // URL is already decoded
+    const url = req.query.url;
+
     if (!url) {
       return res.status(400).json({ error: "URL parameter is required" });
     }


### PR DESCRIPTION
I'm thinking of using this project as a base for my project - to proxy and cache video streams for vrchat. I'm probably going to tailor it more to our use case by integrating yt-dlp sourcing for m3u8 and adding access controls for what can be proxied, but I figured you might want a couple fixes I found.

* The content-type (and cache) headers don't get sent for cached responses, so I just moved up the isM3U8 check and copied the code to send the correct headers - this fixes playing back cached content in vrchat
* I also noticed an issue with url decoding - when proxying a url that contains urlencoded parts (eg. `https://example.com/%3Dthing`), even if you urlencode it so that the server can use that url exactly (eg `https%3A%2F%2Fexample.com%2F%253Dthing`), when the server sends the request, it ends up requesting `https://example.com/=thing` - ie it double urldecodes, since the urldecode appears to already be automatic. This was probably not noticed since most urls will not contain urlencoded parts, but for youtube m3u8s, the urls have lots of urlencoded junk that needs to stay encoded, so removing the extra url decode call fixed it